### PR TITLE
Исправление бага с отсутствием переносов строк

### DIFF
--- a/src/util/dict.ts
+++ b/src/util/dict.ts
@@ -4,7 +4,7 @@ import isInRange from "./isInRange";
  * Таблица символов:
  * 0x00-0x20 (0-32) - пробелы, символы и знаки пунктуации, цифры
  * 0x21-0x63 (33-99) - русский алфавит в двух регистрах
- * 
+ *
  * 1040 - А -> 33
  * 1071 - Я -> 64
  * 1072 - а -> 65
@@ -34,6 +34,7 @@ import isInRange from "./isInRange";
 
         this.addLetter('Ё');
         this.addLetter('ё');
+        this.addLetter('\n');
     }
 
     private addLetter = (letter: string) => {
@@ -58,7 +59,7 @@ import isInRange from "./isInRange";
         }
         this.sequences[sequence] = fixedCode;
         this.codes[fixedCode] = sequence;
-        
+
         return this.size++;
     }
 
@@ -72,22 +73,26 @@ import isInRange from "./isInRange";
      */
     public getFixedCodeByCode = (code: number): number => {
         let fixed = 0;
-        
+
+        if (code === 10) {
+            fixed = 99;
+        }
+
         // Пробел, знаки пунктуации, цифры
         if (isInRange(code, 0x20, 0x40)) {
             fixed = code - 0x20;
         }
-    
+
         // Русский алфавит сдвигаем на место латинского, без "Ё"
         else if (isInRange(code, 1040, 1104) || code === 1105) {
             fixed = code - 1007;
         }
-    
+
         // Если Ё
         else if (code === 1025) {
             fixed = code - 928;
         }
-    
+
         return fixed;
     }
 
@@ -97,11 +102,11 @@ import isInRange from "./isInRange";
      */
     public getCharByCode = (code: number) => {
         let fixed = this.getFixedCodeByCode(code);
-    
+
         if (fixed === null) {
             fixed = 0x1f; // "?"
         }
-        
+
         return String.fromCharCode(fixed);
     }
 


### PR DESCRIPTION
Исправлено неправильное поведение архиватора при попытке сжать текст с переносами строк. Переносы строк (`\n`) игнорировались.